### PR TITLE
fix how it deal with QPS

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -103,7 +103,7 @@ func createCommand() error {
 }
 
 func createObjects(ctx context.Context, clients []*kubernetes.Clientset) {
-	ticker := time.NewTicker(time.Duration(1.0/createConfig.qps) * time.Second)
+	ticker := time.NewTicker(time.Duration(1000000000.0/createConfig.qps) * time.Nanosecond)
 	defer ticker.Stop()
 
 	var wg sync.WaitGroup

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -112,7 +112,7 @@ func listCommand() error {
 
 func listObjects(ctx context.Context, clients []*kubernetes.Clientset) {
 	start := time.Now()
-	ticker := time.NewTicker(time.Duration(1.0/listConfig.qps) * time.Second)
+	ticker := time.NewTicker(time.Duration(1000000000.0/createConfig.qps) * time.Nanosecond)
 	defer ticker.Stop()
 
 	var wg sync.WaitGroup

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/shyamjvs/kube-stress
 
-go 1.17
+go 1.18
 
 require (
 	github.com/google/uuid v1.1.2

--- a/go.sum
+++ b/go.sum
@@ -332,8 +332,6 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=


### PR DESCRIPTION
[time.Duration](https://pkg.go.dev/time#Duration) is an alias of int64. `1.0/createConfig.qps` can go below 1 and `time.Duration(1.0/createConfig.qps) * time.Second` will become 0.
